### PR TITLE
Watchdog 2.0.2

### DIFF
--- a/.ci_support/osx_64_python3.6.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.6.____73_pypy.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.7.____73_pypy.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+  - 10.13                  # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,4 @@
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - 10.13                  # [osx and x86_64]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.13.sdk        # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,5 @@
 # The MacOS version 10.13 has been targeted due to the function kFSEventStreamEventFlagItemCloned that was used
 # https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags/kfseventstreameventflagitemcloned
-# https://github.com/gorakhargosh/watchdog/blob/master/README.rst
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - 10.13                  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:       # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,7 @@
+# The MacOS version 10.13 has been targeted due to the function kFSEventStreamEventFlagItemCloned that was used
+# https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags/kfseventstreameventflagitemcloned
+# https://github.com/gorakhargosh/watchdog/blob/master/README.rst
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - 10.13                  # [osx and x86_64]
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.13.sdk        # [osx]
+CONDA_BUILD_SYSROOT:       # [osx]
+  - /opt/MacOSX10.13.sdk   # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "watchdog" %}
-{% set version = "2.0.0" %}
-{% set hash = "fd4b56cfbe0d0d9c4fc431aceca75700a7f12d3737dc2e9cb2ec2ba649680425" %}
+{% set version = "2.0.1" %}
+{% set hash = "0d1c763652c255e2af00d76cf7d05c7b4867e960092b2696db031f69661c0785" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "watchdog" %}
-{% set version = "1.0.2" %}
-{% set hash = "376cbc2a35c0392b0fe7ff16fbc1b303fd99d4dd9911ab5581ee9d69adc88982" %}
+{% set version = "2.0.0" %}
+{% set hash = "fd4b56cfbe0d0d9c4fc431aceca75700a7f12d3737dc2e9cb2ec2ba649680425" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - watchmedo = watchdog.watchmedo:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "watchdog" %}
-{% set version = "2.0.1" %}
-{% set hash = "0d1c763652c255e2af00d76cf7d05c7b4867e960092b2696db031f69661c0785" %}
+{% set version = "2.0.2" %}
+{% set hash = "532fedd993e75554671faa36cd04c580ced3fae084254a779afbbd8aaf00566b" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
+  run_constrained:
+    - __osx >=10.13
   build:
     - {{ compiler('c') }}  # [osx]
   host:


### PR DESCRIPTION
The recipe is using feature that are only supported in version 10.13 or higher of MacOS
For more information check the information in the link bellow

https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags/kfseventstreameventflagitemcloned

This is an important breaking change that could affect users of older versions of MacOS